### PR TITLE
Fix lwm2m exponentation errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
       "sourceType":"script"
     },
     "rules": {
+      "no-restricted-properties": "WARN",
       "no-param-reassign": "WARN" ,
       "no-underscore-dangle": "WARN",
       "prefer-destructuring": ["ERROR", {"object": true, "array": false}]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,6 @@
       "sourceType":"script"
     },
     "rules": {
-      "no-restricted-properties": "WARN",
       "no-param-reassign": "WARN" ,
       "no-underscore-dangle": "WARN",
       "prefer-destructuring": ["ERROR", {"object": true, "array": false}]

--- a/nodes/lwm2m.js
+++ b/nodes/lwm2m.js
@@ -183,11 +183,11 @@ class ResourceInstance {
       case RESOURCE_TYPE.INTEGER:
         if (this.value === 0) {
           return 0;
-        } else if (this.value < (2 ** 7)) {
+        } else if (this.value < Math.pow(2, 7)) {
           return 1;
-        } else if (this.value < (2 ** 15)) {
+        } else if (this.value < Math.pow(2, 15)) {
           return 2;
-        } else if (this.value < (2 ** 31)) {
+        } else if (this.value < Math.pow(2, 31)) {
           return 4;
         }
         return 8;
@@ -223,9 +223,9 @@ class ResourceInstance {
       this.typeByte.lengthType = Math.ceil(lengthBits / 8);
     }
 
-    typeByteInteger += this.typeByte.identifierType * (2 ** 6);
-    typeByteInteger += this.typeByte.identifierLength * (2 ** 5);
-    typeByteInteger += this.typeByte.lengthType * (2 ** 3);
+    typeByteInteger += this.typeByte.identifierType * Math.pow(2, 6);
+    typeByteInteger += this.typeByte.identifierLength * Math.pow(2, 5);
+    typeByteInteger += this.typeByte.lengthType * Math.pow(2, 3);
     typeByteInteger += this.typeByte.valueLength;
 
     return Buffer.from(typeByteInteger.toString(16), 'hex');
@@ -251,13 +251,13 @@ class ResourceInstance {
         break;
       }
       case RESOURCE_TYPE.INTEGER: {
-        if (2 ** 7 <= this.value && this.value < 2 ** 8) {
+        if (Math.pow(2, 7) <= this.value && this.value < Math.pow(2, 8)) {
           valueBuffer = hexBuffer(`00${this.value.toString(16)}`);
           break;
-        } else if (2 ** 15 <= this.value && this.value < 2 ** 16) {
+        } else if (Math.pow(2, 15) <= this.value && this.value < Math.pow(2, 16)) {
           valueBuffer = hexBuffer(`0000${this.value.toString(16)}`);
           break;
-        } else if (2 ** 31 <= this.value && this.value < 2 ** 32) {
+        } else if (Math.pow(2, 31) <= this.value && this.value < Math.pow(2, 32)) {
           valueBuffer = hexBuffer(`00000000${this.value.toString(16)}`);
           break;
         }

--- a/nodes/lwm2m.js
+++ b/nodes/lwm2m.js
@@ -183,11 +183,11 @@ class ResourceInstance {
       case RESOURCE_TYPE.INTEGER:
         if (this.value === 0) {
           return 0;
-        } else if (this.value < Math.pow(2, 7)) {
+        } else if (this.value >> 7 === 0) { // eslint-disable-line no-bitwise
           return 1;
-        } else if (this.value < Math.pow(2, 15)) {
+        } else if (this.value >> 15 === 0) { // eslint-disable-line no-bitwise
           return 2;
-        } else if (this.value < Math.pow(2, 31)) {
+        } else if (this.value >> 31 === 0) { // eslint-disable-line no-bitwise
           return 4;
         }
         return 8;
@@ -223,9 +223,9 @@ class ResourceInstance {
       this.typeByte.lengthType = Math.ceil(lengthBits / 8);
     }
 
-    typeByteInteger += this.typeByte.identifierType * Math.pow(2, 6);
-    typeByteInteger += this.typeByte.identifierLength * Math.pow(2, 5);
-    typeByteInteger += this.typeByte.lengthType * Math.pow(2, 3);
+    typeByteInteger += this.typeByte.identifierType << 6; // eslint-disable-line no-bitwise
+    typeByteInteger += this.typeByte.identifierLength << 5; // eslint-disable-line no-bitwise
+    typeByteInteger += this.typeByte.lengthType << 3; // eslint-disable-line no-bitwise
     typeByteInteger += this.typeByte.valueLength;
 
     return Buffer.from(typeByteInteger.toString(16), 'hex');
@@ -251,13 +251,13 @@ class ResourceInstance {
         break;
       }
       case RESOURCE_TYPE.INTEGER: {
-        if (Math.pow(2, 7) <= this.value && this.value < Math.pow(2, 8)) {
+        if (this.value >> 7 === 1) { // eslint-disable-line no-bitwise
           valueBuffer = hexBuffer(`00${this.value.toString(16)}`);
           break;
-        } else if (Math.pow(2, 15) <= this.value && this.value < Math.pow(2, 16)) {
+        } else if (this.value >> 15 === 1) { // eslint-disable-line no-bitwise
           valueBuffer = hexBuffer(`0000${this.value.toString(16)}`);
           break;
-        } else if (Math.pow(2, 31) <= this.value && this.value < Math.pow(2, 32)) {
+        } else if (this.value >> 15 === 1) { // eslint-disable-line no-bitwise
           valueBuffer = hexBuffer(`00000000${this.value.toString(16)}`);
           break;
         }


### PR DESCRIPTION
Exponentation operator (**) until node.js version 6.13 causes errors, version 6.13 requires ```--harmony``` flag, therefore I changed it to Math.pow(), because it is supported in early versions of node.js.

http://node.green/#ES2016-features-exponentiation------operator