### PR TITLE
Moved old nodes  to "8devices legacy" section

### DIFF
--- a/nodes/sensor3700_service.html
+++ b/nodes/sensor3700_service.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     RED.nodes.registerType("sensor3700_service in", {
-        category: "input",
+        category: "8devices legacy",
         defaults: {
             uuid: {value: "", required: true},
             measurement: {value: "Active power"},

--- a/nodes/sensor3800_service.html
+++ b/nodes/sensor3800_service.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     RED.nodes.registerType("sensor3800_service in", {
-        category: "input",
+        category: "8devices legacy",
         defaults: {
             uuid: {value: "", required: true},
             interval: {value: 1},

--- a/nodes/sensor4400_service.html
+++ b/nodes/sensor4400_service.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     RED.nodes.registerType("sensor4400_service in", {
-        category: "input",
+        category: "8devices legacy",
         defaults: {
             uuid: {value: "", required: true},
             interval: {value: 1},

--- a/nodes/sensor4500_service.html
+++ b/nodes/sensor4500_service.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     RED.nodes.registerType("sensor4500_service in", {
-        category: "input",
+        category: "8devices legacy",
         defaults: {
             uuid: {value: "", required: true},
             interval: {value: 1},


### PR DESCRIPTION
Old nodes are moved from "input" to "8devices legacy" section.
Resolves #59.